### PR TITLE
Record secret santa pairs to a file

### DIFF
--- a/back_end/.gitignore
+++ b/back_end/.gitignore
@@ -1,1 +1,2 @@
 sendgrid.env
+secret_santas.txt

--- a/back_end/email_sender.py
+++ b/back_end/email_sender.py
@@ -8,12 +8,12 @@ def generate_message(to_email, gift_receiver):
     message = Mail(
         from_email='secret.santa@jordanfallon.com',
         to_emails=to_email
-        )
+    )
 
     message.template_id = TemplateId('d-b1b2395dc84146e4b7cd441de7f01dd2')
     message.dynamic_template_data = {
-            'giftReceiver': gift_receiver,
-        }
+        'giftReceiver': gift_receiver,
+    }
     return message
 
 
@@ -35,7 +35,14 @@ def email_pipeline(match):
     send_message(msg)
 
 
+def record(matches):
+    f = open("secret_santas.txt", "a")
+    f.write(str(matches))
+    f.close()
+
+
 if __name__ == '__main__':
     matches = return_matches_for_everyone()
+    record(matches)
     for match in matches:
         email_pipeline(match)


### PR DESCRIPTION
In case of an email failure or data loss, a file will be written
with secrete santa pairs as a backup. This file is gitignored and
won't be committed, and will only exist on the machine where the
command was run

fixes #11